### PR TITLE
Add tests config for Kubernetes based CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,13 @@ test: build \
 	test-apply \
 	generate-report
 
+test-release: release \
+    test-default-config \
+	test-config-with-variables \
+	test-plan \
+	test-apply \
+	generate-report
+
 prepare-service-principal: guard-CLIENT_ID guard-CLIENT_SECRET guard-SUBSCRIPTION_ID guard-TENANT_ID
 	@echo "$$SERVICE_PRINCIPAL_CONTENT" > $(ROOT_DIR)/service-principal.mk
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,42 @@ or if you want to set different version number:
 ```
 make release VERSION=number_of_your_choice
 ```
+
+# Run tests
+
+```
+make test
+```
+
+# Run tests in Kubernetes based build system
+
+Kubernetes based build system means that build agents work inside Kubernetes cluster. During testing process application runs inside docker container. This means that we've got "docker inside docker (DiD)". This kind of environment requires a bit different configuration of mount shared storage to docker container than with standard one-layer configuration.
+
+With DiD configuration shared volume needs to be created on host machine and this volume is shared with application container as Kubernetes volume.
+Configuration steps:
+
+1.  Create volume  (host path). In deployment.yaml add this config to create kubernetes volume:
+```
+volumes:
+- name: tests-share
+  hostPath:
+    path: /tmp/tests-share
+```
+See manual for more details: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+
+2. Add mount point for kubernetes pod (agent). In deployment.yaml add this config to define volume's mount point:
+```
+volumeMounts:
+- mountPath: /tests-share
+  name: tests-share
+```
+3. Inside pod where tests will run set two variables to indicate host path and mount point:
+```
+export AZBI_K8S_VOL=/tests-share
+export AZBI_MOUNT=/tmp/tests-share  ##modify paths according your needs, but they need to match paths from steps 1 and 2.
+```
+4. Go to location where you downloaded repository and run:
+```
+make test
+```
+5. Test results will be availabe inside ```/tests-share``` on pod on which tests are running and is mapped to ```/tmp/tests-share``` on kubernetes node.

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -247,12 +247,16 @@ selfcheck
 # AZBI_K8S_VOL and AZBI_MOUNT are variables to set up when kubernetes based build agents are in use ('docker in docker')
 # AZBI_K8S_VOL - volume's mount point
 # AZBI_MOUNT - shared folder location on kubernetes host
+AZBI_K8S_VOL=${AZBI_K8S_VOL:-""}
+AZBI_MOUNT=${AZBI_MOUNT:=""}
 TESTS_DIR_TMP="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
-[ -z $AZBI_K8S_VOL ] > /dev/null || mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL 
+if [[ $AZBI_K8S_VOL -ne "" ]]; then
+  mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL
+fi
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -254,8 +254,8 @@ TESTS_DIR=${AZBI_K8S_VOL:=${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:=${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
-if [ $AZBI_K8S_VOL == "\/*" ]; then
-  mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL
+if [ "$AZBI_K8S_VOL" == "\/*" ]; then
+  mkdir -p "$AZBI_K8S_VOL"/shared && cp -r "$TESTS_DIR_TMP"/tests/mocks/ "$AZBI_K8S_VOL"
 fi
 
 # shellcheck disable=SC1090

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -254,7 +254,7 @@ TESTS_DIR=${AZBI_K8S_VOL:=${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:=${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
-if [[ $AZBI_K8S_VOL != "" ]]; then
+if [ $AZBI_K8S_VOL == "\/*" ]; then
   mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL
 fi
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -244,8 +244,9 @@ function cleanup-after-apply() {
 
 selfcheck
 
-TESTS_DIR=/tests-share
-MOUNT_DIR=/tmp/tests-share
+TESTS_DIR_TMP="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
+MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -244,9 +244,15 @@ function cleanup-after-apply() {
 
 selfcheck
 
+# AZBI_K8S_VOL and AZBI_MOUNT are variables to set up when kubernetes based build agents are in use ('docker in docker')
+# AZBI_K8S_VOL - volume's mount point
+# AZBI_MOUNT - shared folder location on kubernetes host
 TESTS_DIR_TMP="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
+
+# Create folder structure inside volume
+[ -z $AZBI_K8S_VOL ] > /dev/null || mkdir -p $AZBI_K8S_VOL/shared && cp -r mocks/ $AZBI_K8S_VOL 
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -252,7 +252,7 @@ TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
-[ -z $AZBI_K8S_VOL ] > /dev/null || mkdir -p $AZBI_K8S_VOL/shared && cp -r mocks/ $AZBI_K8S_VOL 
+[ -z $AZBI_K8S_VOL ] > /dev/null || mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL 
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -95,7 +95,7 @@ function test-apply-suite() {
 function init-default-config() {
   echo "#	will initialize config with \"docker run ... init\" command"
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     init
 }
@@ -110,7 +110,7 @@ function check-default-config-content() {
 function init-2-machines-no-public-ips-named() {
   echo "#	will initialize config with \"docker run ... init M_VMS_COUNT=2 M_PUBLIC_IPS=false M_NAME=azbi-module-tests M_VMS_RSA=test_vms_rsa command\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     init \
     M_VMS_COUNT=2 \
@@ -129,7 +129,7 @@ function check-2-machines-no-public-ips-named-rsa-config-content() {
 function plan-2-machines-no-public-ips-named() {
   echo "#	will plan with \"docker run ... plan M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     plan \
     M_ARM_CLIENT_ID="$2" \
@@ -153,7 +153,7 @@ function check-2-machines-no-public-ips-named-rsa-plan() {
 function apply-2-machines-no-public-ips-named() {
   echo "#	will apply with \"docker run ... apply M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     apply \
     M_ARM_CLIENT_ID="$2" \
@@ -179,7 +179,7 @@ function plan-2-machines-no-public-ips-enable-public-ips() {
   yq w --inplace "$TESTS_DIR"/shared/azbi/azbi-config.yml azbi.use_public_ip true
   echo "#	will plan with \"docker run ... plan M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     plan \
     M_ARM_CLIENT_ID="$2" \
@@ -191,7 +191,7 @@ function plan-2-machines-no-public-ips-enable-public-ips() {
 function apply-2-machines-no-public-ips-enable-public-ips() {
   echo "#	will apply with \"docker run ... apply M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     apply \
     M_ARM_CLIENT_ID="$2" \
@@ -224,7 +224,7 @@ function validate-ssh-connectivity() {
 function cleanup-after-apply() {
   echo "#	will apply with \"docker run ... plan-destroy M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     plan-destroy \
     M_ARM_CLIENT_ID="$2" \
@@ -233,7 +233,7 @@ function cleanup-after-apply() {
     M_ARM_TENANT_ID="$5"
   echo "#	will apply with \"docker run ... destroy M_ARM_CLIENT_ID=... M_ARM_CLIENT_SECRET=... M_ARM_SUBSCRIPTION_ID=... M_ARM_TENANT_ID=...\""
   docker run --rm \
-    -v "$TESTS_DIR"/shared:/shared \
+    -v "$MOUNT_DIR"/shared:/shared \
     -t "$1" \
     destroy \
     M_ARM_CLIENT_ID="$2" \
@@ -245,6 +245,7 @@ function cleanup-after-apply() {
 selfcheck
 
 TESTS_DIR=/tests-share
+MOUNT_DIR=/tmp-tests-share
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -244,7 +244,7 @@ function cleanup-after-apply() {
 
 selfcheck
 
-TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+TESTS_DIR=/tmp/tests-share
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -244,7 +244,7 @@ function cleanup-after-apply() {
 
 selfcheck
 
-TESTS_DIR=/tmp/tests-share
+TESTS_DIR=/tests-share
 
 # shellcheck disable=SC1090
 source "$(dirname "$0")/suite.sh"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -247,11 +247,11 @@ selfcheck
 # AZBI_K8S_VOL and AZBI_MOUNT are variables to set up when kubernetes based build agents are in use ('docker in docker')
 # AZBI_K8S_VOL - volume's mount point
 # AZBI_MOUNT - shared folder location on kubernetes host
-AZBI_K8S_VOL=${AZBI_K8S_VOL:-""}
+AZBI_K8S_VOL=${AZBI_K8S_VOL:=""}
 AZBI_MOUNT=${AZBI_MOUNT:=""}
 TESTS_DIR_TMP="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
-MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
+TESTS_DIR=${AZBI_K8S_VOL:=${TESTS_DIR_TMP}}
+MOUNT_DIR=${AZBI_MOUNT:=${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
 if [[ $AZBI_K8S_VOL != "" ]]; then

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -254,7 +254,7 @@ TESTS_DIR=${AZBI_K8S_VOL:-${TESTS_DIR_TMP}}
 MOUNT_DIR=${AZBI_MOUNT:-${TESTS_DIR_TMP}}
 
 # Create folder structure inside volume
-if [[ $AZBI_K8S_VOL -ne "" ]]; then
+if [[ $AZBI_K8S_VOL != "" ]]; then
   mkdir -p $AZBI_K8S_VOL/shared && cp -r tests/mocks/ $AZBI_K8S_VOL
 fi
 


### PR DESCRIPTION
These changes are necessary to run tests on Kubernetes based build system.

Kubernetes based build system means that build agents work inside Kubernetes cluster. During testing process docker container with application is created. This means that we've got "docker inside docker (DiD)". This kind of environment requires a bit different configuration of mount shared storage to docker container than with standard one-layer configuration.

With DiD configuration shared volume needs to be created on host machine and this volume is shared with application container. 
To create volume use below configuration as template:

```
spec:
  template:
    spec:
      containers:
        volumeMounts:
        - mountPath: /tests-share # kubernetes volume
          name: tests-share
      volumes:
      - name: tests-share
        hostPath:
          path: /tmp/tests-share # hosts' shared location
```

To use this config just setup two variables on you build agent's system:
```
export AZBI_K8S_VOL=/tests-share
export AZBI_MOUNT=/tmp/tests-share
```
These parameters let tests.sh script recognize that is running on Kubernetes CI system.